### PR TITLE
rr-xxx-build-container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+
+# --- ADDED BY THINKIFIC ---
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+WORKDIR /opt/terraform-provider-opsgenie
+
+ADD . .
+
+RUN go build -o ./bin/terraform-provider-opsgenie

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+TAG=opsgenie-builder
+DOCKER_BUILD_FOLDER=/opt/terraform-provider-opsgenie/bin
+
+if [ ! -d "$(pwd)/bin" ]; then
+  mkdir "$(pwd)/bin";
+fi
+
+docker build -t $TAG . &&\
+docker create --name opsgenie-build -it $TAG &&\
+docker cp "opsgenie-build:${DOCKER_BUILD_FOLDER}/terraform-provider-opsgenie" ./bin/terraform-provider-opsgenie &&\
+docker stop opsgenie-build &&\
+docker rm opsgenie-build &&\
+docker rmi -f $TAG &&\
+echo "Opsgenie plugin built and copied to $(pwd)/bin/terraform-provider-opsgenie"

--- a/opsgenie/resource_opsgenie_user.go
+++ b/opsgenie/resource_opsgenie_user.go
@@ -48,6 +48,13 @@ func resourceOpsGenieUser() *schema.Resource {
 				Optional: true,
 				Default:  "America/New_York",
 			},
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: 	  &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -72,6 +79,7 @@ func resourceOpsGenieUserCreate(d *schema.ResourceData, meta interface{}) error 
 		},
 		Locale:   locale,
 		TimeZone: timeZone,
+		Tags:     flattenOpsgenieUserTags(d),
 	}
 
 	log.Printf("[INFO] Creating OpsGenie user '%s'", username)
@@ -106,6 +114,7 @@ func resourceOpsGenieUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("role", usr.Role.RoleName)
 	d.Set("locale", usr.Locale)
 	d.Set("timezone", usr.TimeZone)
+	d.Set("tags", usr.Tags)
 
 	return nil
 }
@@ -131,6 +140,7 @@ func resourceOpsGenieUserUpdate(d *schema.ResourceData, meta interface{}) error 
 		},
 		Locale:   locale,
 		TimeZone: timeZone,
+		Tags:     flattenOpsgenieUserTags(d),
 	}
 
 	_, err = client.Update(context.Background(), updateRequest)
@@ -190,4 +200,19 @@ func validateOpsGenieUserRole(v interface{}, k string) (ws []string, errors []er
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 512 characters: %q %d", k, value, len(value)))
 	}
 	return
+}
+
+func flattenOpsgenieUserTags(d *schema.ResourceData) []string {
+	input := d.Get("tags").(*schema.Set)
+	tags := make([]string, len(input.List()))
+
+	if input == nil {
+		return tags
+	}
+
+	for k, v := range input.List() {
+		tags[k] = v.(string)
+	}
+
+	return tags
 }

--- a/opsgenie/resource_opsgenie_user_test.go
+++ b/opsgenie/resource_opsgenie_user_test.go
@@ -178,7 +178,8 @@ resource "opsgenie_user" "test" {
   full_name = "Acceptance Test User"
   role      = "User"
   locale    = "en_GB"
-  timezone = "Europe/Rome"
+  timezone  = "Europe/Rome"
+  tags      = ["SME"]
 }
 `, rString)
 }

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -19,6 +19,7 @@ resource "opsgenie_user" "test" {
   role      = "User"
   locale    = "en_US"
   timezone  = "America/New_York"
+  tags      = ["user","sme"]
 }
 ```
 
@@ -35,6 +36,8 @@ The following arguments are supported:
 * `locale` - (Optional) Location information for the user. Please look at [Supported Locale Ids](https://docs.opsgenie.com/docs/supported-locales) for available locales.
 
 * `timezone` - (Optional) Timezone information of the user. Please look at [Supported Timezone Ids](https://docs.opsgenie.com/docs/supported-timezone-ids) for available timezones.
+
+* `tags` - (Optional) List of tags to add to the user tags value as a list of strings
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fork OpsGenie Provider repo to allow for us to make customizations without needing to wait for merges from OpsGenie.

Should be a temporary repository until `tags` have been added, but doing it in this way allows us to build the binary needed for Atlantis in a reliable and repeatable manner, regardless of host platform.